### PR TITLE
Dev/macbook

### DIFF
--- a/src/components/store/product-page/container.tsx
+++ b/src/components/store/product-page/container.tsx
@@ -9,6 +9,7 @@ import ReturnsSecurityPrivacyCard from "./returns-security-privacy-card";
 import { cn, isProductValidToAdd } from "@/lib/utils";
 import QuantitySelector from "./quantity-selector";
 import SocialShare from "../shared/social-share";
+import { ProductVariantImage } from "@prisma/client";
 
 interface Props {
 	productData: ProductPageDataType;
@@ -21,6 +22,15 @@ const ProductPageContainer: FC<Props> = ({ productData, sizeId, children }) => {
 	const { images, shippingDetails, sizes } = productData;
 
 	if (typeof shippingDetails === "boolean") return null;
+
+	// State for temporary product images
+	const [variantImages, setVariantImages] =
+		useState<ProductVariantImage[]>(images);
+
+	// useState hook to manage the active image being displayed, initialized to the first image in the array
+	const [activeImage, setActiveImage] = useState<ProductVariantImage | null>(
+		images[0]
+	);
 
 	// Initialize the default product data for the cart item
 	const data: CartProductType = {
@@ -70,13 +80,19 @@ const ProductPageContainer: FC<Props> = ({ productData, sizeId, children }) => {
 		<div className="relative">
 			<div className="w-full xl:flex xl:gap-4">
 				{/* Product images swiper */}
-				<ProductSwiper images={images} />
+				<ProductSwiper
+					images={variantImages.length > 0 ? variantImages : images}
+					activeImage={activeImage || images[0]}
+					setActiveImage={setActiveImage}
+				/>
 				<div className="w-full mt-4 md:mt-0 flex flex-col gap-4 md:flex-row">
 					{/* Product main info */}
 					<ProductInfo
 						productData={productData}
 						sizeId={sizeId}
 						handleChange={handleChange}
+						setVariantImages={setVariantImages}
+						setActiveImage={setActiveImage}
 					/>
 					{/* Shipping details - buy actions buttons */}
 					<div className="w-[390px]">

--- a/src/components/store/product-page/product-info/product-info.tsx
+++ b/src/components/store/product-page/product-info/product-info.tsx
@@ -2,7 +2,7 @@
 import { CartProductType, ProductPageDataType } from "@/lib/types";
 import Image from "next/image";
 import Link from "next/link";
-import { FC } from "react";
+import { Dispatch, FC, SetStateAction } from "react";
 import { CopyIcon } from "@/components/store/icons";
 import toast from "react-hot-toast";
 import ReactStars from "react-rating-stars-component";
@@ -13,12 +13,15 @@ import ColorWheel from "@/components/shared/color-wheel";
 import ProductVariantSelector from "./variant-selector";
 import SizeSelector from "./size.selector";
 import ProductAssurancePolicy from "./assurance-policy";
+import { ProductVariantImage } from "@prisma/client";
 
 interface Props {
 	productData: ProductPageDataType;
 	quantity?: number;
 	sizeId: string | undefined;
 	handleChange: (property: keyof CartProductType, value: any) => void;
+	setVariantImages: Dispatch<SetStateAction<ProductVariantImage[]>>;
+	setActiveImage: Dispatch<SetStateAction<ProductVariantImage | null>>;
 }
 
 const ProductInfo: FC<Props> = ({
@@ -26,6 +29,8 @@ const ProductInfo: FC<Props> = ({
 	quantity,
 	sizeId,
 	handleChange,
+	setVariantImages,
+	setActiveImage,
 }) => {
 	// Check if productData exists return null if it's missing (prevents rendering when no data is available)
 	if (!productData) return null;
@@ -36,7 +41,7 @@ const ProductInfo: FC<Props> = ({
 		name,
 		sku,
 		colors,
-		variantImages,
+		variantsInfo,
 		sizes,
 		isSale,
 		saleEndDate,
@@ -140,10 +145,12 @@ const ProductInfo: FC<Props> = ({
 					</span>
 				</div>
 				<div className="mt-4">
-					{variantImages.length > 0 && (
+					{variantsInfo.length > 0 && (
 						<ProductVariantSelector
-							variants={variantImages}
+							variants={variantsInfo}
 							slug={productData.variantSlug}
+							setVariantImages={setVariantImages}
+							setActiveImage={setActiveImage}
 						/>
 					)}
 				</div>

--- a/src/components/store/product-page/product-info/variant-selector.tsx
+++ b/src/components/store/product-page/product-info/variant-selector.tsx
@@ -1,35 +1,50 @@
+import { VariantInfoType } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { ProductVariantImage } from "@prisma/client";
 import Image from "next/image";
 import Link from "next/link";
-import { FC } from "react";
-
-interface Variant {
-	url: string;
-	img: string;
-	slug: string;
-}
+import { Dispatch, FC, SetStateAction } from "react";
 
 interface Props {
-	variants: Variant[];
+	variants: VariantInfoType[];
 	slug: string;
+	setVariantImages: Dispatch<SetStateAction<ProductVariantImage[]>>;
+	setActiveImage: Dispatch<SetStateAction<ProductVariantImage | null>>;
 }
 
-const ProductVariantSelector: FC<Props> = ({ variants, slug }) => {
+const ProductVariantSelector: FC<Props> = ({
+	variants,
+	slug,
+	setVariantImages,
+	setActiveImage,
+}) => {
 	return (
 		<div className="flex items-center flex-wrap gap-2">
 			{variants.map((variant, i) => (
-				<Link href={variant.url} key={i}>
+				<Link
+					href={variant.variantUrl}
+					key={i}
+					onMouseEnter={() => {
+						setVariantImages(variant.images);
+						setActiveImage(variant.images[0]);
+					}}
+					onMouseLeave={() => {
+						setVariantImages([]);
+						setActiveImage(null);
+					}}
+				>
 					<div
 						className={cn(
 							"w-12 h-12 rounded-full grid place-items-center p-0.5  overflow-hidden border border-transparent hover:border-main-primary cursor-pointer transition-all duration-75 ease-in",
 							{
-								"border-main-primary": slug === variant.slug,
+								"border-main-primary":
+									slug === variant.variantSlug,
 							}
 						)}
 					>
 						<Image
-							src={variant.img}
-							alt={`product variant ${variant.url}`}
+							src={variant.variantImage}
+							alt={`product variant ${variant.variantUrl}`}
 							width={48}
 							height={48}
 							className="rounded-full"

--- a/src/components/store/product-page/product-swiper.tsx
+++ b/src/components/store/product-page/product-swiper.tsx
@@ -1,7 +1,7 @@
 "use client";
 // React, Next.js
 import Image from "next/image";
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 
 // Utils
 import { cn } from "@/lib/utils";
@@ -14,16 +14,15 @@ import ImageZoom from "react-image-zooom";
 
 export default function ProductSwiper({
 	images,
+	activeImage,
+	setActiveImage,
 }: {
 	images: ProductVariantImage[];
+	activeImage: ProductVariantImage | null;
+	setActiveImage: Dispatch<SetStateAction<ProductVariantImage | null>>;
 }) {
 	// If no images are provided, exit early and don't render anything
 	if (!images) return;
-
-	// useState hook to manage the active image being displayed, initialized to the first image in the array
-	const [activeImage, setActiveImage] = useState<ProductVariantImage>(
-		images[0]
-	);
 
 	return (
 		<div className="relative">
@@ -36,11 +35,12 @@ export default function ProductSwiper({
 							className={cn(
 								"w-16 h-16 rounded-md grid place-items-center overflow-hidden border border-gray-100 cursor-pointer transition-all duration-75 ease-in",
 								{
-									"border-main-primary":
-										activeImage.id === img.id,
+									"border-main-primary": activeImage
+										? activeImage.id === img.id
+										: false,
 								}
-                            )}
-                            onMouseEnter={() => setActiveImage(img) }
+							)}
+							onMouseEnter={() => setActiveImage(img)}
 						>
 							<Image
 								src={img.url}
@@ -53,9 +53,9 @@ export default function ProductSwiper({
 					))}
 				</div>
 				{/* Image view */}
-				<div className="relative rounded-lg overflow-hidden w-full 2xl:h-[600px] 2xl:w-[600px]">
+				<div className="relative rounded-lg overflow-hidden md:h-96 md:w-96 2xl:h-[600px] 2xl:w-[600px]">
 					<ImageZoom
-						src={activeImage.url}
+						src={activeImage ? activeImage.url : ""}
 						zoom={200}
 						className="!w-full rounded-lg"
 					/>

--- a/src/components/store/product-page/reviews/product-reviews.tsx
+++ b/src/components/store/product-page/reviews/product-reviews.tsx
@@ -12,6 +12,7 @@ import { Review } from "@prisma/client";
 import ReviewCard from "../../cards/review";
 import { getProductFilteredReviews } from "@/queries/product";
 import ReviewFilters from "./filters";
+import ReviewsSort from "./sort";
 
 interface Props {
 	productId: string;
@@ -93,9 +94,10 @@ const ProductReviews: FC<Props> = ({
 							stats={statistics}
 						/>
 						{/* Review sort */}
+						<ReviewsSort sort={sort} setSort={setSort} />
 					</div>
 					{/* Reviews */}
-					<div className="mt-10 min-h-72 grid grid-cols-2 gap-4">
+					<div className="mt-6 min-h-72 grid grid-cols-2 gap-4">
 						{data.length > 0 ? (
 							<>
 								<div className="flex flex-col gap-3">

--- a/src/components/store/product-page/reviews/product-reviews.tsx
+++ b/src/components/store/product-page/reviews/product-reviews.tsx
@@ -13,6 +13,7 @@ import ReviewCard from "../../cards/review";
 import { getProductFilteredReviews } from "@/queries/product";
 import ReviewFilters from "./filters";
 import ReviewsSort from "./sort";
+import Pagination from "../../shared/pagination";
 
 interface Props {
 	productId: string;
@@ -43,7 +44,7 @@ const ProductReviews: FC<Props> = ({
 
 	// Pagination
 	const [page, setPage] = useState<number>(1);
-	const [pageSize, setPageSize] = useState<number>(2);
+	const [pageSize, setPageSize] = useState<number>(4);
 
 	useEffect(() => {
 		if (filters.rating || filters.hasImages || sort) {
@@ -128,6 +129,17 @@ const ProductReviews: FC<Props> = ({
 						)}
 					</div>
 					{/* Pagination */}
+					{data.length >= pageSize && (
+						<Pagination
+							page={page}
+							setPage={setPage}
+							totalPages={
+								filters.rating || filters.hasImages
+									? data.length / pageSize
+									: totalReviews / pageSize
+							}
+						/>
+					)}
 				</>
 			)}
 		</div>

--- a/src/components/store/product-page/reviews/sort.tsx
+++ b/src/components/store/product-page/reviews/sort.tsx
@@ -1,0 +1,46 @@
+import { ReviewsOrderType } from "@/lib/types";
+import { ChevronDown } from "lucide-react";
+import { Dispatch, FC, SetStateAction } from "react";
+
+interface Props {
+	sort: ReviewsOrderType | undefined;
+	setSort: Dispatch<SetStateAction<ReviewsOrderType | undefined>>;
+}
+
+const ReviewsSort: FC<Props> = ({ sort, setSort }) => {
+	return (
+		<div className="group w-[120px]">
+			{/* Trigger */}
+			<button className="text-main-primary hover:text-[#fd384f] text-sm py-0.5 text-center inline-flex items-center">
+				Sort by{" "}
+				{sort?.orderBy === "latest"
+					? "latest"
+					: sort?.orderBy === "highest"
+					? "highest"
+					: "default"}
+				<ChevronDown className="w-3 ml-1" />
+			</button>
+			<div className="z-10 hidden absolute bg-white shadow w-[120px] group-hover:block">
+				<ul className="text-sm text-gray-700">
+					<li onClick={() => setSort(undefined)}>
+						<span className="block p-2 cursor-pointer hover:bg-gray-100">
+							Sort by default
+						</span>
+					</li>
+					<li onClick={() => setSort({ orderBy: "highest" })}>
+						<span className="block p-2 cursor-pointer hover:bg-gray-100">
+							Sort by highest
+						</span>
+					</li>
+					<li onClick={() => setSort({ orderBy: "latest" })}>
+						<span className="block p-2 cursor-pointer hover:bg-gray-100">
+							Sort by latest
+						</span>
+					</li>
+				</ul>
+			</div>
+		</div>
+	);
+};
+
+export default ReviewsSort;

--- a/src/components/store/shared/pagination.tsx
+++ b/src/components/store/shared/pagination.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@/lib/utils";
+import { MoveLeft, MoveRight } from "lucide-react";
+import { Dispatch, FC, SetStateAction } from "react";
+
+interface Props {
+	page: number;
+	totalPages: number;
+	setPage: Dispatch<SetStateAction<number>>;
+}
+
+const Pagination: FC<Props> = ({ page, totalPages, setPage }) => {
+	const handlePrevious = () => {
+		if (page > 1) {
+			setPage((prev) => prev - 1);
+		}
+    };
+    
+	const handleNext = () => {
+		if (page < totalPages) {
+			setPage((prev) => prev + 1);
+		}
+    };
+    
+	return (
+		<div className="w-full py-10 lg:px-0 sm:px-6 px-4">
+			<div className="w-full flex items-center justify-end gap-x-4 border-t border-gray-200">
+                <div onClick={() => handlePrevious()}
+                    className="flex items-center pt-3 text-gray-600 hover:text-indigo-700 cursor-pointer">
+					<MoveLeft className="w-3" />
+					<p className="text-sm ml-3 font-medium leading-none">
+						Previous
+					</p>
+				</div>
+				<div className="flex flex-wrap">
+					{Array.from({ length: totalPages }).map((_, i) => (
+						<span
+							key={i}
+							className={cn(
+								"text-sm font-medium leading-none cursor-pointer text-gray-600 hover:text-indigo-700 border-t border-transparent hover:border-indigo-400 pt-3 mr-4 px-2",
+								{
+									"border-indigo-400": i + 1 === page,
+								}
+							)}
+							onClick={() => setPage(i + 1)}
+						>
+							{i + 1}
+						</span>
+					))}
+				</div>
+                <div
+                    onClick={() => handleNext()}
+                    className="flex items-center pt-3 text-gray-600 hover:text-indigo-700 cursor-pointer">
+					<MoveRight className="w-3" />
+					<p className="text-sm ml-3 font-medium leading-none">
+						Next
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Pagination;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -171,3 +171,13 @@ export type ReviewsFilterType = {
 export type ReviewsOrderType = {
 	orderBy: "latest" | "oldest" | "highest";
 };
+
+export type VariantInfoType = {
+	variantName: string;
+	variantSlug: string;
+	variantImage: string;
+	variantUrl: string;
+	images: ProductVariantImage[];
+	sizes: Size[];
+	colors: string;
+};

--- a/src/queries/product.ts
+++ b/src/queries/product.ts
@@ -501,23 +501,33 @@ export const retrieveProductDetails = async (
 	});
 
 	if (!product) return null;
-	// Get variant images
-	const variantImages = await db.productVariant.findMany({
+	// Get variant info
+	const variantsInfo = await db.productVariant.findMany({
 		where: {
 			productId: product.id,
 		},
-		select: {
-			slug: true,
-			variantImage: true,
+		include: {
+			images: true,
+			sizes: true,
+			colors: true,
+			product: {
+				select: {
+					slug: true,
+				},
+			},
 		},
 	});
 
 	return {
 		...product,
-		variantImages: variantImages.map((v) => ({
-			url: `/product/${productSlug}/${v.slug}`,
-			img: v.variantImage,
-			slug: v.slug,
+		variantsInfo: variantsInfo.map((variant) => ({
+			variantName: variant.variantName,
+			variantSlug: variant.slug,
+			variantImage: variant.variantImage,
+			variantUrl: `/product/${productSlug}/${variant.slug}`,
+			images: variant.images,
+			sizes: variant.sizes,
+			colors: variant.colors.map((color) => color.name).join(","),
 		})),
 	};
 };
@@ -594,7 +604,7 @@ const formatProductResponse = (
 		reviewsStatistics: ratingStatistics,
 		shippingDetails,
 		relatedProducts: [],
-		variantImages: product.variantImages,
+		variantsInfo: product.variantsInfo,
 	};
 };
 

--- a/src/queries/product.ts
+++ b/src/queries/product.ts
@@ -479,7 +479,7 @@ export const retrieveProductDetails = async (
 					images: true,
 					user: true,
 				},
-				take: 2,
+				take: 4,
 			},
 			freeShipping: {
 				include: {
@@ -816,7 +816,7 @@ export const getProductFilteredReviews = async (
 	},
 	sort: { orderBy: "latest" | "oldest" | "highest" } | undefined,
 	page: number = 1,
-	pageSize: number = 2
+	pageSize: number = 4
 ) => {
 	const reviewFilter: any = {
 		productId,


### PR DESCRIPTION
June 2nd & 3rd 

src/components/store/product-page/product-swiper.tsx

Props must be serializable for components in the "use client" entry file, "setActiveImage" is invalid.ts(71007)
(parameter) setActiveImage: Dispatch<SetStateAction<{
    id: string;
    url: string;
    createdAt: Date;
    updatedAt: Date;
    alt: string;
    productVariantId: string;
} | null>>

このエラーは、Next.js の `use client` コンポーネントで渡している Props の中に「**シリアライズできない値（非プリミティブ型）」が含まれている**ことを示しています。特に、`Date` オブジェクトが原因です。

### 🔍 問題の詳細

Next.js では `use client`（クライアントコンポーネント）に渡す Props は **JSON シリアライズ可能**でなければなりません。つまり、`Date` や `Function`、`Map`、`Set` などのオブジェクトは Props 経由で渡せません。

以下のコードのような `setActiveImage` の `State` の中に `Date` 型のプロパティがあり、それが Props 経由で渡されているのが問題です：

```ts
{
  id: string;
  url: string;
  alt: string;
  productVariantId: string;
  createdAt: Date; // ← これが原因
  updatedAt: Date; // ← これも
}
```

---

### ✅ 解決策

#### ✅ 1. `Date` を文字列に変換して扱う

もし `createdAt` や `updatedAt` がただの表示用であれば、Props に渡す前に `.toISOString()` などで文字列に変換しましょう。

```ts
{
  id: 'abc',
  url: '...',
  alt: '...',
  productVariantId: '123',
  createdAt: new Date().toISOString(),
  updatedAt: new Date().toISOString()
}
```

`createdAt: string` とすれば、Next.js の制限を回避できます。

---

#### ✅ 2. クライアント側の useState にのみ Date を保持する

状態管理（`useState`）内に `Date` を保持したい場合は、`Props` 経由で渡さず、**クライアントコンポーネント内で初期化する**方法が安全です。

---

#### ✅ 3. Props に渡す関数を別の形で扱う（補足）

もし `setActiveImage` そのものを Props として別コンポーネントに渡している場合、その使い方自体は問題ありません。関数は Props に渡せます（コンポーネント間での状態リフトアップは OK）。

ただし、関数で受け渡す「値」がシリアライズ不能（たとえば `Date`）なら、**渡す時点で `string` にしておく**必要があります。

---

### ✳️ まとめ

* ✅ `Date` 型は `string` に変換する。
* ✅ クライアント側でのみ `Date` を保持したい場合は、Props に含めず `useState` 内だけで使う。
* ⚠️ `use client` コンポーネントの Props は「JSON として表現できる値」のみを使う。

