### PR TITLE
191. Creating a Shipping Address Form: Part 1 でのconsole.log("country", form.watch().countryId);でform.watch().countryIdがログに表示されない。 need to check again 現状のコードでは動かないだけの可能性が高い為、対応要検討。is solved!

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model User {
   following Store[]  @relation("UserFollowingStore")
   reviews   Review[] @relation("ReviewToUser")
   cart      Cart?    @relation("UserCart")
-  shippingAddresses ShippingAddress[] @relation("UserShippingAddress")
+  shippingAddresses ShippingAddress[] @relation("UserShippingAddresses")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -419,17 +419,17 @@ model ShippingAddress {
   lastName  String
   phone     String
   address1  String
-  address2  String
+  address2  String?
   state     String
   city      String
   zip_code  String
   default   Boolean @default(false)
 
   userId String
-  user   User   @relation("UserShippingAddress", fields: [userId], references: [id], onDelete: Cascade)
+  user   User   @relation("UserShippingAddresses", fields: [userId], references: [id])
 
   countryId String
-  country   Country @relation("CountryToShippingAddress", fields: [countryId], references: [id], onDelete: Cascade)
+  country   Country @relation("CountryToShippingAddress", fields: [countryId], references: [id])
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/components/shared/country-selector.tsx
+++ b/src/components/shared/country-selector.tsx
@@ -159,6 +159,7 @@ export default function CountrySelector({
                                                     width={20}
                                                     height={20}
                                                     priority
+                                                    style={{ width: 'auto' }}
                                                 />
 
                                                 <span className="truncate font-normal">

--- a/src/components/store/shared/shipping-addresses/address-details.tsx
+++ b/src/components/store/shared/shipping-addresses/address-details.tsx
@@ -29,6 +29,7 @@ import { Button } from '../../ui/button'
 import { Input } from '@/components/ui/input'
 
 // Queries
+import { upsertShippingAddress } from '@/queries/user'
 
 // Utils
 import { v4 } from 'uuid'
@@ -85,7 +86,11 @@ const AddressDetails: FC<AddressDetailsProps> = ({
     // Reset form values when data changes
     useEffect(() => {
         if (data) {
-            form.reset(data)
+            form.reset({
+                ...data,
+                address2: data.address2 || '',
+            })
+            handleCountryChange(data?.country.name)
         }
     }, [data, form])
 
@@ -97,21 +102,31 @@ const AddressDetails: FC<AddressDetailsProps> = ({
             // Upserting Address data
             const response = await upsertShippingAddress({
                 id: data?.id ? data.id : v4(),
+                firstName: values.firstName,
+                lastName: values.lastName,
+                phone: values.phone,
+                address1: values.address1,
+                address2: values.address2 || '',
+                city: values.city,
+                countryId: values.countryId,
+                state: values.state,
+                zip_code: values.zip_code,
+                default: values.default,
+                userId: '',
+                createdAt: new Date(),
+                updatedAt: new Date(),
             })
 
             // Displaying success message
             toast({
                 title: data?.id
-                    ? 'Address has been updated.'
-                    : `Congratulations! '${response?.name}' is now created.`,
+                    ? 'Shipping address has been updated.'
+                    : `Congratulations! Shipping address is now created.`,
             })
 
-            // Redirect or Refresh data
-            if (data?.id) {
-                router.refresh()
-            } else {
-                router.push('/dashboard/admin/categories')
-            }
+            // Refresh data
+            router.refresh()
+            setShow(false)
         } catch (error: any) {
             // Handling form submission errors
             console.log(error)
@@ -124,14 +139,12 @@ const AddressDetails: FC<AddressDetailsProps> = ({
     }
 
     const handleCountryChange = (name: string) => {
-        const country = countries.find((c) => c.id === name)
+        const country = countries.find((c) => c.name === name)
         if (country) {
             form.setValue('countryId', country?.id)
         }
         setCountry(name)
     }
-
-    console.log('country', form.watch().countryId)
 
     return (
         <div>

--- a/src/components/store/shared/shipping-addresses/address-details.tsx
+++ b/src/components/store/shared/shipping-addresses/address-details.tsx
@@ -15,6 +15,7 @@ import * as z from 'zod'
 import { ShippingAddressSchema } from '@/lib/schemas'
 
 // UI Components
+import CountrySelector from '@/components/shared/country-selector'
 import {
     Form,
     FormControl,
@@ -23,7 +24,7 @@ import {
     FormLabel,
     FormMessage,
 } from '@/components/ui/form'
-
+import { Button } from '../../ui/button'
 // import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
@@ -37,8 +38,6 @@ import { useRouter } from 'next/navigation'
 
 // types
 import { SelectMenuOption, UserShippingAddressType } from '@/lib/types'
-import { Button } from '../../ui/button'
-import CountrySelector from '@/components/shared/country-selector'
 
 interface AddressDetailsProps {
     data?: UserShippingAddressType
@@ -46,7 +45,11 @@ interface AddressDetailsProps {
     setShow: Dispatch<SetStateAction<boolean>>
 }
 
-const AddressDetails: FC<AddressDetailsProps> = ({ data, countries, setShow }) => {
+const AddressDetails: FC<AddressDetailsProps> = ({
+    data,
+    countries,
+    setShow,
+}) => {
     // Initializing necessary hooks
     const { toast } = useToast() // Hook for displaying toast messages
     const router = useRouter() // Hook for routing
@@ -75,7 +78,7 @@ const AddressDetails: FC<AddressDetailsProps> = ({ data, countries, setShow }) =
             default: data?.default ?? false,
         },
     })
-    
+
     // Loading status based on form submission
     const isLoading = form.formState.isSubmitting
 
@@ -128,8 +131,8 @@ const AddressDetails: FC<AddressDetailsProps> = ({ data, countries, setShow }) =
         setCountry(name)
     }
 
-    console.log("country", form.watch().countryId);
-    
+    console.log('country', form.watch().countryId)
+
     return (
         <div>
             <Form {...form}>
@@ -139,7 +142,7 @@ const AddressDetails: FC<AddressDetailsProps> = ({ data, countries, setShow }) =
                 >
                     <div className="space-y-2">
                         <FormLabel>Contact information</FormLabel>
-                        <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center justify-between gap-3">
                             <FormField
                                 control={form.control}
                                 name="firstName"
@@ -175,7 +178,7 @@ const AddressDetails: FC<AddressDetailsProps> = ({ data, countries, setShow }) =
                             control={form.control}
                             name="phone"
                             render={({ field }) => (
-                                <FormItem className="!mt-6 w-[calc(50%-8px)] flex-1">
+                                <FormItem className="!mt-3 w-[calc(50%-8px)] flex-1">
                                     <FormControl>
                                         <Input
                                             placeholder="Phone number"
@@ -194,7 +197,7 @@ const AddressDetails: FC<AddressDetailsProps> = ({ data, countries, setShow }) =
                                 control={form.control}
                                 name="countryId"
                                 render={({ field }) => (
-                                    <FormItem className="!mt-6 w-[calc(50%-8px)] flex-1">
+                                    <FormItem className="!mt-3 w-[calc(50%-8px)] flex-1">
                                         <FormControl>
                                             <CountrySelector
                                                 id={'countries'}
@@ -219,8 +222,91 @@ const AddressDetails: FC<AddressDetailsProps> = ({ data, countries, setShow }) =
                                 )}
                             />
                         </div>
+                        <div className="!mt-3 flex items-center justify-between gap-3">
+                            <FormField
+                                control={form.control}
+                                name="address1"
+                                render={({ field }) => (
+                                    <FormItem className="flex-1">
+                                        <FormControl>
+                                            <Input
+                                                placeholder="Street, house/apartment/unit"
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="address2"
+                                render={({ field }) => (
+                                    <FormItem className="flex-1">
+                                        <FormControl>
+                                            <Input
+                                                placeholder="Apt, suite, unit, etc (optional)"
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                        <div className="!mt-3 flex items-center justify-between gap-3">
+                            <FormField
+                                control={form.control}
+                                name="city"
+                                render={({ field }) => (
+                                    <FormItem className="flex-1">
+                                        <FormControl>
+                                            <Input
+                                                placeholder="City"
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="state"
+                                render={({ field }) => (
+                                    <FormItem className="flex-1">
+                                        <FormControl>
+                                            <Input
+                                                placeholder="State/Province"
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                        <FormField
+                            control={form.control}
+                            name="zip_code"
+                            render={({ field }) => (
+                                <FormItem className="!mt-3 w-[calc(50%-8px)] flex-1">
+                                    <FormControl>
+                                        <Input
+                                            placeholder="Zip code"
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
                     </div>
-                    <Button type="submit" disabled={isLoading}>
+                    <Button
+                        type="submit"
+                        disabled={isLoading}
+                        className="rounded-md"
+                    >
                         {isLoading
                             ? 'loading...'
                             : data?.id

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -210,4 +210,5 @@ export type CartWithCartItemsType = Cart & {
 
 export type UserShippingAddressType = ShippingAddress & {
     country: CountryPrisma
+    user: User
 }


### PR DESCRIPTION
根本的な原因は以下にあり。
③ handleCountryChange() の処理ロジックのミス
以下のように書かれていた：

```
const handleCountryChange = (name: string) => {
    const country = countries.find((c) => c.id === name)
```
→ これは name（= Countryの名前） を使って id に対して比較しているので、常に undefined になります。

issueに合わせてコンソールに出ていた以下の警告も対応済み。
`hook.js:608 Image with src "https://purecatamphetamine.github.io/country-flag-icons/3x2/UA.svg" has either width or height modified, but not the other. If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.
overrideMethod @ hook.js:608
warnOnce @ warn-once.ts:6
eval @ image-component.tsx:163`

この警告は、`<Image>` コンポーネントに `width` か `height` の一方だけを変更したときに **縦横比（アスペクト比）を維持できない可能性**があるために出ています。

## 🔧 原因の詳細

Next.js の `<Image>` コンポーネントでは `width` と `height` を指定するか、`layout="fill"` を使ってアスペクト比を明示的に維持するように設計されています。

警告文:

> Image with src ... has either width or height modified, but not the other...

これはつまり、「`height` は指定されてるが `width` が CSS で変えられてる（またはその逆）」という状態。

---

## ✅ 解決策（どちらかで対応可能）

### ✔ ① `style={{ height: 'auto' }}` or `style={{ width: 'auto' }}` を追加

このケースでは、`<Image>` に `width` / `height` が指定されていて、`className` の中でさらに `height: 1rem` (`h-4`) を指定しているため、それが原因です。

### 🔁 修正方法の例

```tsx
<Image
  alt={`${selectedValue.name}`}
  src={`https://purecatamphetamine.github.io/country-flag-icons/3x2/${selectedValue.code}.svg`}
  className="mr-2 inline h-4 rounded-sm"
  width={20}
  height={20}
  priority
  style={{ width: 'auto' }} // 👈 追加
/>
```

または、逆に `height: auto` を設定してもよいです（ただし Tailwind で上書きされないように注意）。

---

### ✔ ② CSSでサイズを完全に制御するなら、`fill` モードを使用

```tsx
<div className="relative h-4 w-auto">
  <Image
    src={...}
    alt={...}
    fill // 👈 アスペクト比を維持したまま親要素にフィット
    className="object-contain rounded-sm"
    priority
  />
</div>
```

この場合、親要素が `relative` で `h-*` と `w-*` を設定している必要があります。

---

## 💡補足

Tailwind CSSで `h-4` などの高さを指定しているとき、それが `Image` コンポーネントの `height` 属性や `style` と矛盾すると警告が出やすいです。Next.js の `<Image>` コンポーネントは通常、**アスペクト比の維持を期待**するためです。

---

## ✅ 結論

簡単に直したいなら、以下のように `style={{ width: 'auto' }}` を追加するのが最も手軽で安全です。

```tsx
<Image
  ...略...
  width={20}
  height={20}
  style={{ width: 'auto' }}
/>
```

---
