### PR TITLE
Added keyboard accessibility to the cart quantity controls and harden…

### DIFF
--- a/src/components/store/cards/cart-product.tsx
+++ b/src/components/store/cards/cart-product.tsx
@@ -300,6 +300,20 @@ const CartProduct: FC<Props> = ({
                                                 'remove'
                                             )
                                         }
+                                        onKeyDown={(event) => {
+                                            if (
+                                                event.key === 'Enter' ||
+                                                event.key === ' '
+                                            ) {
+                                                event.preventDefault();
+                                                updateProductQuantityHandler(
+                                                    'remove'
+                                                );
+                                            }
+                                        }}
+                                        role="button"
+                                        tabIndex={0}
+                                        aria-label="Decrease quantity"
                                         data-testid="cart-qty-decrease"
                                     >
                                         <Minus className="stroke-[#555] w-3" />
@@ -318,6 +332,20 @@ const CartProduct: FC<Props> = ({
                                         onClick={() =>
                                             updateProductQuantityHandler('add')
                                         }
+                                        onKeyDown={(event) => {
+                                            if (
+                                                event.key === 'Enter' ||
+                                                event.key === ' '
+                                            ) {
+                                                event.preventDefault();
+                                                updateProductQuantityHandler(
+                                                    'add'
+                                                );
+                                            }
+                                        }}
+                                        role="button"
+                                        tabIndex={0}
+                                        aria-label="Increase quantity"
                                         data-testid="cart-qty-increase"
                                     >
                                         <Plus className="stroke-[#555] w-3" />

--- a/tests/e2e/seed/seed-e2e.ts
+++ b/tests/e2e/seed/seed-e2e.ts
@@ -35,6 +35,41 @@ const parseListEnv = (value?: string) =>
         .map((entry) => entry.trim())
         .filter(Boolean);
 
+const normalizeWorkerCount = (value: unknown, fallback: number) => {
+    const normalizeNumber = (count: number) => {
+        if (!Number.isFinite(count)) {
+            return fallback;
+        }
+        const normalized = Math.floor(count);
+        return normalized >= 1 ? normalized : fallback;
+    };
+
+    if (typeof value === "number") {
+        return normalizeNumber(value);
+    }
+
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return fallback;
+        }
+        if (trimmed.endsWith("%")) {
+            const percentage = Number.parseFloat(trimmed.slice(0, -1));
+            if (!Number.isFinite(percentage)) {
+                return fallback;
+            }
+            const computed = Math.floor(
+                (percentage / 100) * os.cpus().length
+            );
+            return computed >= 1 ? computed : fallback;
+        }
+        const parsed = Number.parseInt(trimmed, 10);
+        return normalizeNumber(parsed);
+    }
+
+    return fallback;
+};
+
 const resolveSeedTargets = (): SeedTarget[] => {
     const explicitWorkerIndex = parseIntEnv(
         process.env.TEST_WORKER_INDEX || process.env.E2E_WORKER_INDEX
@@ -64,8 +99,10 @@ const resolveSeedTargets = (): SeedTarget[] => {
     const fallbackProjectNames =
         resolvedProjectNames.length > 0 ? resolvedProjectNames : [undefined];
 
-    const defaultWorkerCount =
-        parseIntEnv(process.env.PLAYWRIGHT_WORKERS) || os.cpus().length;
+    const defaultWorkerCount = normalizeWorkerCount(
+        process.env.PLAYWRIGHT_WORKERS,
+        os.cpus().length
+    );
 
     return fallbackProjectNames.flatMap((projectName) => {
         const projectConfig = configProjects.find(
@@ -74,11 +111,12 @@ const resolveSeedTargets = (): SeedTarget[] => {
         if (explicitWorkerIndex !== undefined) {
             return [{ projectName, workerIndex: explicitWorkerIndex }];
         }
-        const workerCount =
+        const workerCount = normalizeWorkerCount(
             workerOverride ??
-            projectConfig?.workers ??
-            playwrightConfig.workers ??
-            defaultWorkerCount;
+                projectConfig?.workers ??
+                playwrightConfig.workers,
+            defaultWorkerCount
+        );
         return Array.from({ length: workerCount }, (_, workerIndex) => ({
             projectName,
             workerIndex,
@@ -261,16 +299,6 @@ const seedOnce = async (seed: ReturnType<typeof buildE2ESeed>) => {
 
     return { country, user, store, category, subCategory, product, variant };
 };
-
-async function main() {
-    const seedTargets = resolveSeedTargets();
-
-    for (const target of seedTargets) {
-        const seed = buildE2ESeed(target);
-        await seedOnce(seed);
-    }
-    console.log(`E2E seed completed (${seedTargets.length} target(s)).`);
-}
 
 async function main() {
     const seedTargets = resolveSeedTargets();


### PR DESCRIPTION
…ed the E2E seed worker parsing so Playwright percent-based worker configs won’t break, while also removing the duplicate main() definition in the seed script.

cart-product.tsx adds onKeyDown handling for Enter/Space plus role=button, tabIndex={0}, and aria-label for both quantity controls so they’re keyboard operable. seed-e2e.ts normalizes workers values (number or percent string) before building the target list and removes the duplicate async function main().

@coderabbitai review