### PR TITLE
PROGRESS の追記運用に合わせてガイド文を修正し、今回の追加対応分を日付付きで末尾に追記しました。変更理由は「差し替え」ではなく「追…

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -3,9 +3,18 @@
 > This document is updated by team agreement and kept current.
 
 ## Quality Bar
-- No P0/P1 bugs open for release; P2 allowed with a documented plan.
+- No P0/P1 bugs open for release; P2 allowed only with a documented mitigation plan
+  stored in the project tracker and linked from the PR.
+  - Approval: Tech Lead + Product Manager.
+  - Required fields: root cause, user impact, mitigation steps, owner, target date.
 - Critical flows (browse -> cart -> checkout -> payment) have E2E smoke coverage.
-- New server actions and validations include unit tests or a written waiver.
+- Non-critical flows must have at least one automated test per area
+  (unit/component for UI or integration for server actions). Target areas:
+  search/browse, profile management, seller store setup, admin catalog.
+- New server actions and validations include unit tests or a formal test waiver.
+  - Waiver record: tracker ticket with label `test-waiver` and link in PR description.
+  - Approval: QA Lead or Engineering Manager.
+  - Required fields: scope, risk, compensating coverage, expiry date (<= 90 days).
 - UI changes must be checked on mobile and desktop breakpoints.
 
 ## Non-Functional Requirements

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,7 +3,7 @@
 ## ドキュメントガイド
 - 本レポートは特定日付時点の進捗サマリ
 - 関連: `README.md`, `TESTING_DESIGN.md`
-- 次回更新時は日付・範囲・コミット一覧を最新に差し替える
+- 追記は日付付きで末尾に追加する
 
 ## 範囲
 - 基準コミット: `bc45c4f89da632eef8084ced9ddc33220ba1b63c`
@@ -51,3 +51,9 @@
 ## 付記
 - シークレットは表示・コミットしていない
 - テスト生成物はGit管理対象外とする方針
+
+## 追記 (2025-12-21)
+- KiloCode/Spec Kit の導入（`.kilocode/`, `.specify/`, `specs/` 雛形追加）
+- 仕様書テンプレ整備とサンプル仕様の具体化（`specs/001-sample-feature`）
+- 運用ルールと品質基準の明文化（`README_kilocode_speckit.md`, `constitution.md`）
+- `.gitignore` に KiloCode/Spec Kit のキャッシュ除外を追加


### PR DESCRIPTION
…記」で履歴を残す方針に合わせるためです。PROGRESS_2025-12-21.md

追記セクションに KiloCode/Spec Kit 導入・テンプレ整備・品質基準の明文化・.gitignore 追記を記録。レビュー指摘に沿って「Quality Bar」を具体化し、記録場所・承認者・必須項目・有効期限まで明記しました。非クリティカルフローのテスト期待値も対象領域と最低要件を追加しています。 constitution.md