### PR TITLE
Fix test mocks and refactor star colors to Tailwind classes

### DIFF
--- a/src/components/store/forms/review-details.test.tsx
+++ b/src/components/store/forms/review-details.test.tsx
@@ -177,7 +177,7 @@ describe('ReviewDetails Component Tests', () => {
         const star = screen.getByTestId('star-wrapper-2');
 
         // 最初はイエローの星はない
-        expect(document.querySelectorAll('svg[fill="#FFD804"]').length).toBe(0);
+        expect(document.querySelectorAll('svg.text-yellow-400').length).toBe(0);
 
         // getBoundingClientRect を確実に上書きモック
         Object.defineProperty(star, 'getBoundingClientRect', {
@@ -194,11 +194,11 @@ describe('ReviewDetails Component Tests', () => {
 
         // clientX = 30 のとき、x = 30 >= 20 なので、3.0 になる
         fireEvent.mouseMove(star, { clientX: 30 });
-        expect(document.querySelectorAll('svg[fill="#FFD804"]').length).toBeGreaterThan(0);
+        expect(document.querySelectorAll('svg.text-yellow-400').length).toBeGreaterThan(0);
 
         // mouseLeave でホバーがリセットされる
         fireEvent.mouseLeave(star);
-        expect(document.querySelectorAll('svg[fill="#FFD804"]').length).toBe(0);
+        expect(document.querySelectorAll('svg.text-yellow-400').length).toBe(0);
     });
 
     it('should handle click with clientX to select partial rating', () => {

--- a/src/components/store/forms/review-details.test.tsx
+++ b/src/components/store/forms/review-details.test.tsx
@@ -8,6 +8,14 @@ jest.mock('@/queries/review', () => ({
     upsertReview: jest.fn(),
 }));
 
+jest.mock('react-hot-toast', () => ({
+    __esModule: true,
+    default: {
+        success: jest.fn(),
+        error: jest.fn(),
+    }
+}));
+
 // uuid もモック化して ESM のパースエラーを防ぐ
 jest.mock('uuid', () => ({
     v4: () => 'mock-uuid-v4',
@@ -100,6 +108,10 @@ const mockSetReviews = jest.fn();
 describe('ReviewDetails Component Tests', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     it('should render rating stars and update rating on click', async () => {
@@ -344,8 +356,10 @@ describe('ReviewDetails Component Tests', () => {
 
         await waitFor(() => {
             expect(upsertReview).toHaveBeenCalled();
-            expect(consoleErrorSpy).toHaveBeenCalled();
-        });
-        consoleErrorSpy.mockRestore();
+            const hasTargetError = consoleErrorSpy.mock.calls.some(call => 
+                typeof call[0] === 'string' && call[0].includes('Failed to add review:')
+            );
+            expect(hasTargetError).toBe(true);
+        }, { timeout: 3000 });
     });
 });

--- a/src/components/store/forms/review-details.tsx
+++ b/src/components/store/forms/review-details.tsx
@@ -116,15 +116,15 @@ function CustomRatingStars({
                         {/* Empty Star Background */}
                         <Star
                             size={size}
-                            className="text-[#e2dfdf] absolute top-0 left-0"
-                            fill="#e2dfdf"
+                            className="text-slate-300 absolute top-0 left-0"
+                            fill="currentColor"
                         />
                         {/* Active Star Overlay */}
                         {isFull && (
                             <Star
                                 size={size}
-                                className="text-[#FFD804] absolute top-0 left-0"
-                                fill="#FFD804"
+                                className="text-yellow-400 absolute top-0 left-0"
+                                fill="currentColor"
                             />
                         )}
                         {isHalf && (
@@ -134,8 +134,8 @@ function CustomRatingStars({
                             >
                                 <Star
                                     size={size}
-                                    className="text-[#FFD804]"
-                                    fill="#FFD804"
+                                    className="text-yellow-400"
+                                    fill="currentColor"
                                 />
                             </div>
                         )}


### PR DESCRIPTION
主な対応内容は以下の通りです。

  1. UI改善: レーティングスターのカラー設定をTailwind CSSに移行
  カスタムレーティングコンポーネントにおいて、ハードコードされていた16進数のカラーコードをTailwind CSSのクラスに置き換えました。

   * 対象ファイル:
       * src/components/store/forms/review-details.tsx
       * src/components/store/forms/review-details.test.tsx
   * 変更点:
       * アクティブな星の色: #FFD804 → text-yellow-400
       * 空の星の色: #e2dfdf → text-slate-300
       * SVGの fill 属性を currentColor に変更し、Tailwindのテキストカラークラスが適用されるように修正しました。
   * テストの更新:
       * CSSクラスの変更に伴い、テストコード内のセレクタ（svg[fill="#FFD804"]
         など）を新しいクラス名（svg.text-yellow-400）に更新し、テストが正しく動作することを確認しました。