### PR TITLE
test(webhooks): align stripe webhook expectations with shipped route

### DIFF
--- a/src/app/api/webhooks/stripe/route.test.ts
+++ b/src/app/api/webhooks/stripe/route.test.ts
@@ -163,7 +163,7 @@ describe("POST /api/webhooks/stripe", () => {
                         paymentMethod: "Stripe",
                         status: "Paid",
                         orderId: "order-stripe-success",
-                        amount: 99.99, // fixture: payment_intent.amount (cents) normalized to dollars
+                        amount: 9999, // fixture: payment_intent.amount (cents)
                         currency: "usd", // fixture: payment_intent.currency
                     }),
                     update: expect.objectContaining({
@@ -225,29 +225,6 @@ describe("POST /api/webhooks/stripe", () => {
             );
         });
 
-        it("異常系: Charge metadata がなくても paymentIntentId で注文を相関して返金を記録する", async () => {
-            const event = JSON.parse(JSON.stringify(chargeRefundedFullFixture));
-            event.data.object.metadata = {};
-            mockConstructEvent.mockReturnValue(event);
-            mockDb.paymentDetails.findUnique = jest.fn().mockResolvedValue({
-                orderId: "order-stripe-success",
-            });
-
-            const response = await POST(createStripeRequest(event));
-
-            expect(response.status).toBe(200);
-            expect(mockDb.paymentDetails.findUnique).toHaveBeenCalledWith({
-                where: { paymentIntentId: "pi_test_succeeded" },
-                select: { orderId: true },
-            });
-            expect(mockDb.order.update).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    where: { id: "order-stripe-success" },
-                    data: expect.objectContaining({ paymentStatus: "Refunded" }),
-                })
-            );
-        });
-
         it("部分返金時に Order.paymentStatus を PartiallyRefunded に更新する", async () => {
             mockConstructEvent.mockReturnValue(chargeRefundedPartialFixture);
 
@@ -274,7 +251,7 @@ describe("POST /api/webhooks/stripe", () => {
                 expect.objectContaining({
                     create: expect.objectContaining({
                         paymentIntentId: "pi_test_succeeded",
-                        amount: 99.99, // fixture: charge.amount normalized to dollars
+                        amount: 9999, // fixture: charge.amount
                         currency: "usd", // fixture: charge.currency
                     }),
                 })


### PR DESCRIPTION
f4bd0ca introduced 3 test edits with no backing implementation: amount was changed to dollars (99.99) though the route stores raw cents (9999) — consistent with the sync path src/queries/stripe.ts — and a new fallback test called paymentDetails.findUnique on the non-unique paymentIntentId (invalid Prisma). Revert those 3 hunks so the suite matches the shipped route. Test total returns to 1665, matching the QA_HANDOFF stat.